### PR TITLE
Dynamic checkout URL and modernize example code

### DIFF
--- a/vipps-checkout-api.md
+++ b/vipps-checkout-api.md
@@ -127,7 +127,7 @@ Here is an example integration written in JavaScript that will make a request to
         };
 
         // Call merchant backend which will again call Checkout backend to establish session
-        fetch(merchantBackendAppUrl + '/create-checkout-session', {
+        fetch(`${merchantBackendAppUrl}/create-checkout-session`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -143,7 +143,7 @@ Here is an example integration written in JavaScript that will make a request to
             window.location.href = updateQueryStringParameter('token', data.token);
           })
           .catch(function (error) {
-            console.error('Error:', error);
+            console.error('Error: ', error);
           });
       });
 

--- a/vipps-checkout-api.md
+++ b/vipps-checkout-api.md
@@ -121,12 +121,11 @@ Here is an example integration written in JavaScript that will make a request to
 
       // When clicking the "Checkout with Vipps" button
       document.getElementById('checkout-button').addEventListener('click', function () {
-
-        // Set the amount of the purchase here in oere
-        var data = {
-          amount: '1600',
+        // Define some data the merchant backend can use to determine what product/cost it should create a session for
+        const data = {
+          productId: 1,
         };
-        
+
         // Call merchant backend which will again call Checkout backend to establish session
         fetch(merchantBackendAppUrl + '/create-checkout-session', {
           method: 'POST',

--- a/vipps-checkout-api.md
+++ b/vipps-checkout-api.md
@@ -150,19 +150,20 @@ Here is an example integration written in JavaScript that will make a request to
 
       // Helper functions
       function updateQueryStringParameter(key, value) {
-        var uri = window.location.href;
-        var re = new RegExp('([?&])' + key + '=.*?(&|$)', 'i');
-        var separator = uri.indexOf('?') !== -1 ? '&' : '?';
-        if (uri.match(re)) {
-          return uri.replace(re, '$1' + key + '=' + value + '$2');
-        } else {
-          return uri + separator + key + '=' + value;
-        }
+        const url = new URL(window.location.href);
+        const urlParams = url.searchParams;
+
+        urlParams.append(key, value);
+        url.search = urlParams.toString();
+
+        return url.toString();
       }
+
       function getParameterByName(name) {
-        var match = RegExp(`[?&]${name}=([^&]*)`).exec(window.location.search);
-        var result = match && decodeURIComponent(match[1].replace(/\+/g, ' '));
-        return result;
+        const queryString = window.location.search;
+        const urlParams = new URLSearchParams(queryString);
+
+        return urlParams.get(name);
       }
     </script>
   </body>

--- a/vipps-checkout-api.md
+++ b/vipps-checkout-api.md
@@ -71,7 +71,7 @@ Here is an example integration written in JavaScript that will make a request to
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta

--- a/vipps-checkout-api.md
+++ b/vipps-checkout-api.md
@@ -87,13 +87,15 @@ Here is an example integration written in JavaScript that will make a request to
     </section>
     <section id="vipps-checkout-frame-container"></section>
     <script>
-      var merchantBackendAppUrl = '<THE BACKEND OF THE MERCHANT TO RECEIVE CALLBACK>';
-      var checkoutFrontendUrl = '<URL TO VIPPS CHECKOUT>';
-      
+      const merchantBackendAppUrl = '<THE BACKEND OF THE MERCHANT TO RECEIVE CALLBACK>'; // replace me!
+
+      const token = getParameterByName('token');
+      const checkoutFrontendUrl = window.localStorage.getItem(`vipps-checkout-${token}`);
+
       // Setup iframe element and container to hold the iframe
-      var frameContainer = document.getElementById('vipps-checkout-frame-container');
-      var iframe = document.createElement('iframe');
-      var iframeId = 'vipps-checkout-iframe';
+      const frameContainer = document.getElementById('vipps-checkout-frame-container');
+      const iframe = document.createElement('iframe');
+      const iframeId = 'vipps-checkout-iframe';
       iframe.frameBorder = '0';
       iframe.width = '100%';
 
@@ -111,9 +113,8 @@ Here is an example integration written in JavaScript that will make a request to
       );
 
       // If token query parameter present, we don't need to start a new session and load the current one.
-      var token = getParameterByName('token');
       if (token) {
-        iframe.src = checkoutFrontendUrl + '/?token=' + token;
+        iframe.src = `${checkoutFrontendUrl}/?token=${token}`;
         iframe.id = iframeId;
         frameContainer.appendChild(iframe);
       }
@@ -139,6 +140,7 @@ Here is an example integration written in JavaScript that will make a request to
           })
           .then(function (data) {
             // Set token in URL and update the address field of the browser.
+            window.localStorage.setItem('vipps-checkout-' + data.token, data.checkoutFrontendUrl);
             window.location.href = updateQueryStringParameter('token', data.token);
           })
           .catch(function (error) {


### PR DESCRIPTION
Because of the special note saying that URLs should not being hard-coded I propose a solution using `localStorage` in order to avoid hard-coding `checkoutFrontendUrl`.

![image](https://user-images.githubusercontent.com/3168421/121048069-bdf72c80-c7b6-11eb-8ee1-242ce9120713.png)

In addition I ensured the `data` object passed to the merchant back-end does not contain an amount value as this practice should not be encouraged from a security point of view. Developers should of course know not to do this in their own implementations, but I have unfortunately seen developers fail to consider this many times previously 😅

I've also gone ahead and modernized the code used in `updateQueryStringParameter` and `getParameterByName` and the rest of the example for readability. The only 'current' browser that does not support the URL API is Internet Explorer which will soon be history and [not even supported by Microsoft's Office 365](https://www.theverge.com/2020/8/17/21372487/microsoft-internet-explorer-11-support-end-365-legacy-edge). If this is a decision by choice and you would like me to undo this part of the PR I would happily do so. I do recognize that some companies still need <=IE11 support although I am unsure about how widespread that currently is 😊