### PR TITLE
Fix broken metadata

### DIFF
--- a/vipps-checkout-how-it-works-shipping.md
+++ b/vipps-checkout-how-it-works-shipping.md
@@ -1,6 +1,6 @@
 <!-- START_METADATA
 ---
-title: How it works: shipping
+title: How it works(shipping)
 sidebar_position: 11
 ---
 END_METADATA -->


### PR DESCRIPTION
In order to have : in metadata you need to use quotes, for example `"title: How it works: shipping"` but for whatever reason the markdown renderer in docusaurus turns that into `How it works :shipping` so i suggest using parenthesis instead.