### PR TITLE
Remove id because it broke the links

### DIFF
--- a/vipps-checkout-api-quick-start.md
+++ b/vipps-checkout-api-quick-start.md
@@ -2,7 +2,6 @@
 ---
 title: Quick start for the Checkout API
 sidebar_label: Quick start
-id: quick-start
 sidebar_position: 5
 description: Quick steps for getting started with the Checkout API.
 toc_min_heading_level: 2


### PR DESCRIPTION
Revert id. 
It turns out that 'id' renamed the file in docusaurus.